### PR TITLE
base64 terraform env private_key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ provider "transip" {
 }
 
 # Or simply empty when using the environment variables TRANSIP_ACCOUNT_NAME and TRANSIP_PRIVATE_KEY
+# To make sure Terraform can read the environment variable, it needs the prefix TF_VAR_ which in this case results to
+# TF_VAR_TRANSIP_PRIVATE_KEY
+# Preferably, this private key is encoded in base64 to preserve the format (i.e. when using it with GitLab-CI/CD). 
+# This can then be read by Terraform like so:
+
+provider "transip" {
+  private_key = "${base64decode(var.private_key)}"
+}
+
 # provider "transip" { }
 
 # Get an existing domain as data source


### PR DESCRIPTION
First things first, really appreciate the work you've put into this module, it's working great!

However, when using it in my GitLab-CI process I had some issues figuring out how to correctly supply the environment variables. Therefore I wrote some instructions to use base64 on your environment variables and how Terraform reads those. 

Feel free to edit it a little to your taste, thanks!