### PR TITLE
Add TransIP private network resource & attachment

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -16,3 +16,6 @@ export TF_VAR_domain=example.com
 
 # name of VPS to use for testing, the VPS will be read from but not modified.
 export TF_VAR_vps_name=example-vps
+
+# name of the private network used for testing, the private network will be read from but not modified.
+export TF_VAR_private_network_name=accountname-privatenetwork

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -49,7 +49,7 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 
 	p, err := repository.GetByName(name)
 	if err != nil {
-		return fmt.Errorf("failed to lookup private network %q: %s", d.Id(), err)
+		return fmt.Errorf("failed to lookup private network %q: %s", name, err)
 	}
 
 	log.Printf("[DEBUG] terraform-provider-transip success: private network %s found, getting details.\n", name)

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -70,27 +70,3 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 
 	return nil
 }
-
-// func getPrivateNetworkID(d *schema.ResourceData, m interface{}) error {
-// 	description := d.Get("description").(string)
-// 	client := m.(repository.Client)
-// 	repository := vps.PrivateNetworkRepository{Client: client}
-
-// 	all, err := repository.GetAll()
-// 	if err != nil {
-// 		return fmt.Errorf("failed to get all private networks: %s", err)
-// 	}
-
-// 	found := false
-// 	for _, privateNetwork := range all {
-// 		if privateNetwork.Description == description {
-// 			d.SetId(privateNetwork.Name)
-// 			found = true
-// 			return nil
-// 		}
-// 	}
-// 	if !found {
-// 		return (fmt.Errorf("Private network with description %s not found", description))
-// 	}
-// 	return nil
-// }

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/transip/gotransip/v6/repository"
+	"github.com/transip/gotransip/v6/vps"
+)
+
+func dataSourcePrivateNetwork() *schema.Resource {
+	return &schema.Resource{
+		Read: resourcePrivateNetworkRead,
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Required: true,
+				Type:     schema.TypeString,
+				ForceNew: true,
+			},
+			"name": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"is_blocked": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"is_locked": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"vps_names": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+	return nil
+}
+
+func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	getPrivateNetworkID(d, m)
+
+	p, err := repository.GetByName(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to lookup private network %q: %s", d.Id(), err)
+	}
+
+	var vpsNames []string
+	for _, vpsName := range p.VpsNames {
+		vpsNames = append(vpsNames, vpsName)
+	}
+
+	d.Set("name", d.Id())
+	d.Set("description", p.Description)
+	d.Set("is_blocked", p.IsBlocked)
+	d.Set("is_locked", p.IsLocked)
+	d.Set("vps_names", vpsNames)
+
+	return nil
+}
+
+func getPrivateNetworkID(d *schema.ResourceData, m interface{}) error {
+	description := d.Get("description").(string)
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	all, err := repository.GetAll()
+	if err != nil {
+		return fmt.Errorf("failed to get all private networks: %s", err)
+	}
+
+	found := false
+	for _, privateNetwork := range all {
+		if privateNetwork.Description == description {
+			d.SetId(privateNetwork.Name)
+			found = true
+			return nil
+		}
+	}
+	if !found {
+		return (fmt.Errorf("Private network with description %s not found", description))
+	}
+	return nil
+}

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -45,7 +45,6 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := vps.PrivateNetworkRepository{Client: client}
 	name := d.Get("name").(string)
-	// getPrivateNetworkID(d, m)
 
 	p, err := repository.GetByName(name)
 	if err != nil {

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -38,7 +38,6 @@ func dataSourcePrivateNetwork() *schema.Resource {
 			},
 		},
 	}
-	return nil
 }
 
 func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/transip/gotransip/v6/repository"
@@ -10,14 +11,14 @@ import (
 
 func dataSourcePrivateNetwork() *schema.Resource {
 	return &schema.Resource{
-		Read: resourcePrivateNetworkRead,
+		Read: dataSourcePrivateNetworkRead,
 		Schema: map[string]*schema.Schema{
-			"description": {
+			"name": {
 				Required: true,
 				Type:     schema.TypeString,
 				ForceNew: true,
 			},
-			"name": {
+			"description": {
 				Computed: true,
 				Type:     schema.TypeString,
 			},
@@ -43,21 +44,26 @@ func dataSourcePrivateNetwork() *schema.Resource {
 func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := vps.PrivateNetworkRepository{Client: client}
+	name := d.Get("name").(string)
+	// getPrivateNetworkID(d, m)
 
-	getPrivateNetworkID(d, m)
-
-	p, err := repository.GetByName(d.Id())
+	p, err := repository.GetByName(name)
 	if err != nil {
 		return fmt.Errorf("failed to lookup private network %q: %s", d.Id(), err)
 	}
 
+	log.Printf("[DEBUG] terraform-provider-transip success: private network %s found, getting details.\n", name)
 	var vpsNames []string
 	for _, vpsName := range p.VpsNames {
+		log.Printf("[DEBUG] terraform-provider-transip success: private network %s has vps %s \n", name, vpsName)
 		vpsNames = append(vpsNames, vpsName)
 	}
 
-	d.Set("name", d.Id())
+	d.SetId(name)
+
+	d.Set("name", name)
 	d.Set("description", p.Description)
+	log.Printf("[DEBUG] terraform-provider-transip success: private network %s has description %s \n", name, p.Description)
 	d.Set("is_blocked", p.IsBlocked)
 	d.Set("is_locked", p.IsLocked)
 	d.Set("vps_names", vpsNames)
@@ -65,26 +71,26 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func getPrivateNetworkID(d *schema.ResourceData, m interface{}) error {
-	description := d.Get("description").(string)
-	client := m.(repository.Client)
-	repository := vps.PrivateNetworkRepository{Client: client}
+// func getPrivateNetworkID(d *schema.ResourceData, m interface{}) error {
+// 	description := d.Get("description").(string)
+// 	client := m.(repository.Client)
+// 	repository := vps.PrivateNetworkRepository{Client: client}
 
-	all, err := repository.GetAll()
-	if err != nil {
-		return fmt.Errorf("failed to get all private networks: %s", err)
-	}
+// 	all, err := repository.GetAll()
+// 	if err != nil {
+// 		return fmt.Errorf("failed to get all private networks: %s", err)
+// 	}
 
-	found := false
-	for _, privateNetwork := range all {
-		if privateNetwork.Description == description {
-			d.SetId(privateNetwork.Name)
-			found = true
-			return nil
-		}
-	}
-	if !found {
-		return (fmt.Errorf("Private network with description %s not found", description))
-	}
-	return nil
-}
+// 	found := false
+// 	for _, privateNetwork := range all {
+// 		if privateNetwork.Description == description {
+// 			d.SetId(privateNetwork.Name)
+// 			found = true
+// 			return nil
+// 		}
+// 	}
+// 	if !found {
+// 		return (fmt.Errorf("Private network with description %s not found", description))
+// 	}
+// 	return nil
+// }

--- a/data_source_transip_private_network.go
+++ b/data_source_transip_private_network.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/transip/gotransip/v6/repository"
@@ -51,10 +50,8 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("failed to lookup private network %q: %s", name, err)
 	}
 
-	log.Printf("[DEBUG] terraform-provider-transip success: private network %s found, getting details.\n", name)
 	var vpsNames []string
 	for _, vpsName := range p.VpsNames {
-		log.Printf("[DEBUG] terraform-provider-transip success: private network %s has vps %s \n", name, vpsName)
 		vpsNames = append(vpsNames, vpsName)
 	}
 
@@ -62,7 +59,6 @@ func dataSourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", name)
 	d.Set("description", p.Description)
-	log.Printf("[DEBUG] terraform-provider-transip success: private network %s has description %s \n", name, p.Description)
 	d.Set("is_blocked", p.IsBlocked)
 	d.Set("is_locked", p.IsLocked)
 	d.Set("vps_names", vpsNames)

--- a/data_source_transip_private_network_test.go
+++ b/data_source_transip_private_network_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccTransipDataSourcePrivateNetwork(t *testing.T) {
+	privateNetworkName := os.Getenv("TF_VAR_private_network_name")
+	if privateNetworkName == "" {
+		t.Skip("TF_VAR_private_network_name not provided, skipping")
+	}
 	var testConfig = `data "transip_private_network" "test" {name = "%s"}`
 
 	resource.Test(t, resource.TestCase{
@@ -16,9 +20,9 @@ func TestAccTransipDataSourcePrivateNetwork(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testConfig, os.Getenv("TF_VAR_private_network_name")),
+				Config: fmt.Sprintf(testConfig, privateNetworkName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.transip_private_network.test", "name", os.Getenv("TF_VAR_private_network_name")),
+					resource.TestCheckResourceAttr("data.transip_private_network.test", "name", privateNetworkName),
 				),
 			},
 		},

--- a/data_source_transip_private_network_test.go
+++ b/data_source_transip_private_network_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTransipDataSourcePrivateNetwork(t *testing.T) {
+	var testConfig = `data "transip_private_network" "test" {name = "%s"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testConfig, os.Getenv("TF_VAR_private_network_name")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.transip_private_network.test", "name", os.Getenv("TF_VAR_private_network_name")),
+				),
+			},
+		},
+	})
+}

--- a/examples/private_network.tf
+++ b/examples/private_network.tf
@@ -1,3 +1,12 @@
+variable "private_network_name" {
+    default = "test"
+}
+
+# the private network data resource can be created by using the unique name TransIP assigns to the resource. (You can view this in the control panel)
+data "transip_private_network" "test" {
+    name = var.private_network_name
+}
+
 # order a new private network, or use `terraform import transip_private_netwerk.test test` to import existing one
 resource "transip_private_network" "test" {
   description = "test" # Description is the user defined name, as the name attribute is set by TransIP as a unique ID.

--- a/examples/private_network.tf
+++ b/examples/private_network.tf
@@ -1,0 +1,4 @@
+# order a new private network, or use `terraform import transip_private_netwerk.test test` to import existing one
+resource "transip_private_network" "test" {
+  description = "test" # Description is the user defined name, as the name attribute is set by TransIP as a unique ID.
+}

--- a/provider.go
+++ b/provider.go
@@ -70,6 +70,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"transip_domain": dataSourceDomain(),
 			"transip_vps":    dataSourceVps(),
+			"transip_private_network": dataSourcePrivateNetwork(),
 		},
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/transip/gotransip/v6"
-	"github.com/transip/gotransip/v6/authenticator"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/transip/gotransip/v6"
+	"github.com/transip/gotransip/v6/authenticator"
 )
 
 func envBoolFunc(k string) schema.SchemaDefaultFunc {
@@ -59,9 +60,11 @@ func Provider() *schema.Provider {
 		ConfigureFunc: providerConfigure,
 
 		ResourcesMap: map[string]*schema.Resource{
-			"transip_dns_record": resourceDNSRecord(),
-			"transip_domain":     resourceDomain(),
-			"transip_vps":        resourceVps(),
+			"transip_dns_record":                 resourceDNSRecord(),
+			"transip_domain":                     resourceDomain(),
+			"transip_vps":                        resourceVps(),
+			"transip_private_network":            resourcePrivateNetwork(),
+			"transip_private_network_attachment": resourcePrivateNetworkAttachment(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/provider_test.go
+++ b/provider_test.go
@@ -41,6 +41,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	if v := os.Getenv("TF_VAR_private_network_name"); v == "" {
-		t.Fatal("TF_VAR_private_network_name must be set for acceptance tests")
+		t.Skip("TF_VAR_private_network_name not provided, skipping test.")
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -39,4 +39,8 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("TF_VAR_domain"); v == "" {
 		t.Fatal("TF_VAR_domain must be set for acceptance tests")
 	}
+
+	if v := os.Getenv("TF_VAR_private_network_name"); v == "" {
+		t.Fatal("TF_VAR_private_network_name must be set for acceptance tests")
+	}
 }

--- a/resource_transip_private_network.go
+++ b/resource_transip_private_network.go
@@ -17,9 +17,9 @@ func resourcePrivateNetwork() *schema.Resource {
 		Read:   resourcePrivateNetworkRead,
 		// Update: resourcePrivateNetworkUpdate,
 		Delete: resourcePrivateNetworkDelete,
-		// Importer: &schema.ResourceImporter{
-		// 	State: schema.ImportStatePassthrough,
-		// },
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"description": {
 				Required: true,

--- a/resource_transip_private_network.go
+++ b/resource_transip_private_network.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/transip/gotransip/v6"
+	"github.com/transip/gotransip/v6/repository"
+	"github.com/transip/gotransip/v6/vps"
+)
+
+func resourcePrivateNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePrivateNetworkCreate,
+		Read:   resourcePrivateNetworkRead,
+		// Update: resourcePrivateNetworkUpdate,
+		Delete: resourcePrivateNetworkDelete,
+		// Importer: &schema.ResourceImporter{
+		// 	State: schema.ImportStatePassthrough,
+		// },
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Required: true,
+				Type:     schema.TypeString,
+				ForceNew: true,
+			},
+			"name": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"is_blocked": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"is_locked": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"vps_names": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourcePrivateNetworkCreate(d *schema.ResourceData, m interface{}) error {
+	description := d.Get("description").(string)
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	err := repository.Order(description)
+	if err != nil {
+		return fmt.Errorf("failed to order private network %s: %s", description, err)
+
+	}
+	setPrivateNetworkID(d, m)
+
+	return resourcePrivateNetworkRead(d, m)
+}
+
+func resourcePrivateNetworkRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	p, err := repository.GetByName(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to lookup private network %q: %s", d.Id(), err)
+	}
+
+	var vpsNames []string
+	for _, vpsName := range p.VpsNames {
+		vpsNames = append(vpsNames, vpsName)
+	}
+
+	d.Set("name", d.Id())
+	d.Set("description", p.Description)
+	d.Set("is_blocked", p.IsBlocked)
+	d.Set("is_locked", p.IsLocked)
+	d.Set("vps_names", vpsNames)
+
+	return nil
+}
+
+func resourcePrivateNetworkDelete(d *schema.ResourceData, m interface{}) error {
+	description := d.Get("description")
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	err := repository.Cancel(d.Id(), gotransip.CancellationTimeImmediately)
+	if err != nil {
+		return fmt.Errorf("failed to cancel private network %s with id %q: %s", description, d.Id(), err)
+	}
+
+	return nil
+}
+
+func setPrivateNetworkID(d *schema.ResourceData, m interface{}) error {
+	description := d.Get("description").(string)
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		log.Printf("[DEBUG] terraform-provider-transip trying to get id for private network %s \n", description)
+
+		// The set description in the Terraform resource is not the same as the name used to query details about a private network.
+		// You'll need the unique name Transip generates to get the private network details.
+		all, err := repository.GetAll()
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("failed to get all private networks: %s", err))
+		}
+		for _, privateNetwork := range all {
+			if privateNetwork.Description == description {
+				d.SetId(privateNetwork.Name)
+				log.Printf("[DEBUG] terraform-provider-transip id found for private network %s:%s \n", description, d.Id())
+			}
+		}
+		if d.Id() == "" {
+			return resource.RetryableError(fmt.Errorf("Failed to set ID for private network %s", description))
+		}
+		return resource.NonRetryableError(resourcePrivateNetworkRead(d, m))
+	})
+}

--- a/resource_transip_private_network_attachment.go
+++ b/resource_transip_private_network_attachment.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/transip/gotransip/v6/repository"
+	"github.com/transip/gotransip/v6/vps"
+)
+
+func resourcePrivateNetworkAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePrivateNetworkAttachmentCreate,
+		Read:   resourcePrivateNetworkAttachmentRead,
+		// Update: resourcePrivateNetworkUpdate,
+		Delete: resourcePrivateNetworkAttachmentDelete,
+		// Importer: &schema.ResourceImporter{
+		// 	State: schema.ImportStatePassthrough,
+		// },
+		Schema: map[string]*schema.Schema{
+			"private_network_id": {
+				Required: true,
+				Type:     schema.TypeString,
+				ForceNew: true,
+			},
+			"vps_id": {
+				Required: true,
+				Type:     schema.TypeString,
+				ForceNew: true,
+			},
+			"action": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourcePrivateNetworkAttachmentCreate(d *schema.ResourceData, m interface{}) error {
+	privateNetworkID := d.Get("private_network_id").(string)
+	vpsID := d.Get("vps_id").(string)
+
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		log.Printf("[DEBUG] terraform-provider-transip trying to attach network %s to vps %s \n", privateNetworkID, vpsID)
+
+		err := repository.AttachVps(vpsID, privateNetworkID)
+		if err != nil {
+			if strings.Contains(err.Error(), fmt.Sprintf("VPS '%s' has an action running, no modification is allowed", vpsID)) {
+				log.Printf("[DEBUG] terraform-provider-transip VPS %s busy, retrying to attach to %s in a bit \n", vpsID, privateNetworkID)
+				return resource.RetryableError(fmt.Errorf("failed to attach VPS %s to private network %s, VPS busy: %s", vpsID, privateNetworkID, err))
+			}
+			log.Printf("[DEBUG] terraform-provider-transip something went wrong while attaching VPS %s to %s \n", vpsID, privateNetworkID)
+			return resource.NonRetryableError(fmt.Errorf("failed to attach private network %s to VPS %s: %s", privateNetworkID, vpsID, err))
+		}
+		return resource.NonRetryableError(resourcePrivateNetworkAttachmentRead(d, m))
+	})
+}
+
+func resourcePrivateNetworkAttachmentRead(d *schema.ResourceData, m interface{}) error {
+	privateNetworkID := d.Get("private_network_id").(string)
+	vpsID := d.Get("vps_id").(string)
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	p, err := repository.GetByName(privateNetworkID)
+	if err != nil {
+		return fmt.Errorf("failed to lookup private network %q: %s", d.Id(), err)
+	}
+
+	found := false
+	for _, vpsName := range p.VpsNames {
+		if vpsName == vpsID {
+			log.Printf("[DEBUG] terraform-provider-transip success: vps %s is the same as %s in private network %s \n", vpsID, vpsName, privateNetworkID)
+			found = true
+			break
+		}
+		if !found {
+			d.SetId("")
+			log.Printf("[DEBUG] terraform-provider-transip vps %s not found in private network %s \n", vpsID, privateNetworkID)
+		}
+	}
+	d.SetId(p.Name)
+	return nil
+}
+
+func resourcePrivateNetworkAttachmentDelete(d *schema.ResourceData, m interface{}) error {
+	privateNetworkID := d.Get("private_network_id").(string)
+	vpsID := d.Get("vps_id").(string)
+
+	client := m.(repository.Client)
+	repository := vps.PrivateNetworkRepository{Client: client}
+
+	err := repository.DetachVps(vpsID, privateNetworkID)
+	if err != nil {
+		return fmt.Errorf("failed to detach private network %s to VPS %s: %s", privateNetworkID, vpsID, err)
+	}
+	return nil
+}

--- a/resource_transip_private_network_attachment_test.go
+++ b/resource_transip_private_network_attachment_test.go
@@ -11,12 +11,16 @@ import (
 )
 
 func TestAccTransipResourcePrivateNetworkAttachment(t *testing.T) {
+	privateNetworkName := os.Getenv("TF_VAR_private_network_name")
+	if privateNetworkName == "" {
+		t.Skip("TF_VAR_private_network_name not provided, skipping")
+	}
 	testConfig := fmt.Sprintf(`
 	resource "transip_private_network_attachment" "test" {
 		private_network_id = "%s"
 		vps_id = "%s"
 	}
-	`, os.Getenv("TF_VAR_private_network_name"), os.Getenv("TF_VAR_vps_name"))
+	`, privateNetworkName, os.Getenv("TF_VAR_vps_name"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -26,9 +30,9 @@ func TestAccTransipResourcePrivateNetworkAttachment(t *testing.T) {
 				Config:        testConfig,
 				ResourceName:  "transip_private_network_attachment.test",
 				ImportState:   false,
-				ImportStateId: os.Getenv("TF_VAR_private_network_name"),
+				ImportStateId: privateNetworkName,
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if s[0].ID != os.Getenv("TF_VAR_private_network_name") {
+					if s[0].ID != privateNetworkName {
 						return fmt.Errorf("import failed")
 					}
 					return nil

--- a/resource_transip_private_network_attachment_test.go
+++ b/resource_transip_private_network_attachment_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"os"
+	"testing"
+)
+
+func TestAccTransipResourcePrivateNetworkAttachment(t *testing.T) {
+	testConfig := fmt.Sprintf(`
+	resource "transip_private_network_attachment" "test" {
+		private_network_id = "%s"
+		vps_id = "%s"
+	}
+	`, os.Getenv("TF_VAR_private_network_name"), os.Getenv("TF_VAR_vps_name"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:        testConfig,
+				ResourceName:  "transip_private_network_attachment.test",
+				ImportState:   false,
+				ImportStateId: os.Getenv("TF_VAR_private_network_name"),
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if s[0].ID != os.Getenv("TF_VAR_private_network_name") {
+						return fmt.Errorf("import failed")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/resource_transip_private_network_test.go
+++ b/resource_transip_private_network_test.go
@@ -12,11 +12,15 @@ import (
 )
 
 func TestAccTransipResourcePrivateNetwork(t *testing.T) {
+	privateNetworkName := os.Getenv("TF_VAR_private_network_name")
+	if privateNetworkName == "" {
+		t.Skip("TF_VAR_private_network_name not provided, skipping")
+	}
 	testConfig := fmt.Sprintf(`
 	resource "transip_private_network" "test" {
     	description = "%s"
 	}
-	`, os.Getenv("TF_VAR_private_network_name"))
+	`, privateNetworkName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -26,9 +30,9 @@ func TestAccTransipResourcePrivateNetwork(t *testing.T) {
 				Config:        testConfig,
 				ResourceName:  "transip_private_network.test",
 				ImportState:   true,
-				ImportStateId: os.Getenv("TF_VAR_private_network_name"),
+				ImportStateId: privateNetworkName,
 				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if s[0].ID != os.Getenv("TF_VAR_private_network_name") {
+					if s[0].ID != privateNetworkName {
 						return fmt.Errorf("import failed")
 					}
 					return nil

--- a/resource_transip_private_network_test.go
+++ b/resource_transip_private_network_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTransipResourcePrivateNetwork(t *testing.T) {
+	testConfig := fmt.Sprintf(`
+	resource "transip_private_network" "test" {
+    	description = "%s"
+	}
+	`, os.Getenv("TF_VAR_private_network_name"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:        testConfig,
+				ResourceName:  "transip_private_network.test",
+				ImportState:   true,
+				ImportStateId: os.Getenv("TF_VAR_private_network_name"),
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if s[0].ID != os.Getenv("TF_VAR_private_network_name") {
+						return fmt.Errorf("import failed")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -51,12 +50,6 @@ func resourceVps() *schema.Resource {
 				ForceNew: true,
 			},
 			"install_text": {
-				Optional: true,
-				Type:     schema.TypeString,
-				Default:  "",
-				ForceNew: true,
-			},
-			"private_network": {
 				Optional: true,
 				Type:     schema.TypeString,
 				Default:  "",
@@ -127,7 +120,6 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 	availabilityZone := d.Get("availability_zone").(string)
 	addons := []string{}
 	InstallText := d.Get("install_text").(string)
-	privateNetwork := d.Get("private_network").(string)
 
 	client := m.(repository.Client)
 	repository := vps.Repository{Client: client}
@@ -166,10 +158,6 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("install_text", InstallText)
 	setVpsID(d, m)
-
-	if privateNetwork != "" {
-		attachPrivateNetwork(d, m)
-	}
 
 	return resourceVpsRead(d, m)
 }
@@ -234,34 +222,6 @@ func resourceVpsDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return nil
-}
-
-func attachPrivateNetwork(d *schema.ResourceData, m interface{}) error {
-	// Use unique ID from TransIP
-	id := d.Id()
-	name := d.Get("name").(string)
-	privateNetwork := d.Get("private_network").(string)
-
-	client := m.(repository.Client)
-	repository := vps.PrivateNetworkRepository{Client: client}
-	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		log.Printf("[DEBUG] terraform-provider-transip attaching VPS %s with id %s to private network %s \n", name, id, privateNetwork)
-
-		err := repository.AttachVps(id, privateNetwork)
-		if err != nil {
-			if strings.Contains(err.Error(), fmt.Sprintf("VPS with name '%s' not found", name)) || strings.Contains(err.Error(), "Identifier 'vpsName' missing") {
-				return resource.RetryableError(fmt.Errorf("Failed to attach VPS %s with unique-id %s to private network %s: %s", name, id, privateNetwork, err))
-			}
-			return resource.NonRetryableError(fmt.Errorf("Failed to attach VPS %s with unique-id %s to private network %s: %s", name, id, privateNetwork, err))
-		}
-		attached, err := repository.GetByName(privateNetwork)
-		for _, vps := range attached.VpsNames {
-			if vps == d.Id() {
-				return resource.NonRetryableError(resourceVpsRead(d, m))
-			}
-		}
-		return resource.RetryableError(fmt.Errorf("VPS %s with unique-id %s does not exist in private network %s: %s", name, id, privateNetwork, err))
-	})
 }
 
 func setVpsID(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
This resource makes use of a main resource and an attachment like other providers do as well. First you create a `private_network` resource after which you'd want to attach each VPS using a `private_network_attachment`

For example:

```
resource "transip_vps" "test" {
  name = "test"
  product_name = "vps-bladevps-x1"
  operating_system = "Debian 9"
}

resource "transip_private_network" {
    description = "test"
}

resource "transip_private_network_attachment" {
  private_network_id = transip_private_network.test.id
  vps_id = transip_vps.test.id

}
```

Please let me know if you notice any issues or bad practices, as this is my first experience with Go and/or extending Terraform Providers