### PR TITLE
VPS firewall support

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -63,6 +63,7 @@ func Provider() *schema.Provider {
 			"transip_dns_record":                 resourceDNSRecord(),
 			"transip_domain":                     resourceDomain(),
 			"transip_vps":                        resourceVps(),
+			"transip_vps_firewall":               resourceVpsFirewall(),
 			"transip_private_network":            resourcePrivateNetwork(),
 			"transip_private_network_attachment": resourcePrivateNetworkAttachment(),
 		},

--- a/resource_transip_vps_firewall.go
+++ b/resource_transip_vps_firewall.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transip/gotransip/v6/vps"
 )
 
-func retryableErrorf(err error, format string, a ...interface{}) *resource.RetryError {
+func retryableVpsFirewallErrorf(err error, format string, a ...interface{}) *resource.RetryError {
 	// Format the error
 	e := fmt.Errorf(format+": %s", append(a, err)...)
 
@@ -143,7 +143,7 @@ func resourceVpsFirewallCreate(d *schema.ResourceData, m interface{}) error {
 		log.Printf("[DEBUG] terraform-provider-transip updating VPS firewall %s (%v)\n", name, firewall.RuleSet)
 		err := repository.UpdateFirewall(name, firewall)
 		if err != nil {
-			return retryableErrorf(err, "failed to update vps firewall %q", name)
+			return retryableVpsFirewallErrorf(err, "failed to update vps firewall %q", name)
 		}
 		d.SetId(name)
 
@@ -168,7 +168,7 @@ func resourceVpsFirewallDelete(d *schema.ResourceData, m interface{}) error {
 		log.Printf("[DEBUG] terraform-provider-transip removing VPS firewall %s\n", name)
 		err := repository.UpdateFirewall(name, firewall)
 		if err != nil {
-			return retryableErrorf(err, "failed to delete vps firewall %q", name)
+			return retryableVpsFirewallErrorf(err, "failed to delete vps firewall %q", name)
 		}
 		return nil
 	})

--- a/resource_transip_vps_firewall.go
+++ b/resource_transip_vps_firewall.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/transip/gotransip/v6/repository"
 	"github.com/transip/gotransip/v6/vps"

--- a/resource_transip_vps_firewall.go
+++ b/resource_transip_vps_firewall.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/transip/gotransip/v6/repository"
+	"github.com/transip/gotransip/v6/vps"
+)
+
+func resourceVpsFirewall() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVpsFirewallCreate,
+		Read:   resourceVpsFirewallRead,
+		Delete: resourceVpsFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the vps",
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				ForceNew:    true,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether the firewall is enabled for this VPS",
+			},
+			"inbound_rule": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Ruleset of the VPS",
+				Elem:        vpsFirewallRuleSchema(),
+			},
+		},
+	}
+}
+
+func vpsFirewallRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Description of the rule",
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Default:      "tcp",
+				ValidateFunc: validation.StringInSlice([]string{"tcp", "udp", "tcp_udp"}, false),
+				Description:  "Protocol for this rule (tcp, udp or tcp_udp)",
+			},
+			"port": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "Network port for this rule",
+			},
+			"whitelist": {
+				Type:     schema.TypeList,
+				ForceNew: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.CIDRNetwork(0, 32),
+				},
+				Description: "Whitelisted IP’s or ranges that are allowed to connect, empty to allow all",
+			},
+		},
+	}
+}
+
+func resourceVpsFirewallRead(d *schema.ResourceData, m interface{}) error {
+	name := d.Id()
+
+	// Obtain the firewall for the VPS
+	client := m.(repository.Client)
+	repository := vps.FirewallRepository{Client: client}
+	v, err := repository.GetFirewall(name)
+	if err != nil {
+		return fmt.Errorf("failed to lookup vps firewall %q: %s", name, err)
+	}
+
+	// Convert all inbound API rules to state rules
+	inboundRules := make([]interface{}, len(v.RuleSet))
+	for i, rule := range v.RuleSet {
+		inboundRules[i] = vpsFirewallRuleFlatten(&rule)
+	}
+
+	// Load information
+	d.SetId(name)
+	d.Set("name", name)
+	d.Set("is_enabled", v.IsEnabled)
+	d.Set("inbound_rule", inboundRules)
+
+	return nil
+}
+
+func resourceVpsFirewallCreate(d *schema.ResourceData, m interface{}) error {
+	name := d.Get("name").(string)
+
+	// Create the API firewall
+	var firewall vps.Firewall
+	firewall.IsEnabled = d.Get("is_enabled").(bool)
+
+	// Convert all inbound state rules to API rules
+	inboundRules := d.Get("inbound_rule").(*schema.Set)
+	for _, rule := range inboundRules.List() {
+		r, err := vpsFirewallRuleExpand(rule)
+		if err != nil {
+			return err
+		}
+		firewall.RuleSet = append(firewall.RuleSet, *r)
+	}
+
+	// Set the firewall for the VPS
+	client := m.(repository.Client)
+	repository := vps.FirewallRepository{Client: client}
+	err := repository.UpdateFirewall(name, firewall)
+	if err != nil {
+		return fmt.Errorf("failed to update vps firewall %q: %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceVpsFirewallRead(d, m)
+}
+
+func resourceVpsFirewallDelete(d *schema.ResourceData, m interface{}) error {
+	name := d.Id()
+
+	// Create an empty firewall which is also disabled
+	var firewall vps.Firewall
+	firewall.IsEnabled = false
+	firewall.RuleSet = make([]vps.FirewallRule, 0)
+
+	// Set the empty firewall for the VPS
+	client := m.(repository.Client)
+	repository := vps.FirewallRepository{Client: client}
+	err := repository.UpdateFirewall(name, firewall)
+	if err != nil {
+		return fmt.Errorf("failed to delete vps firewall %q: %s", name, err)
+	}
+
+	return nil
+}

--- a/resource_transip_vps_firewall_test.go
+++ b/resource_transip_vps_firewall_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/transip/gotransip/v6/repository"
 	"github.com/transip/gotransip/v6/vps"

--- a/resource_transip_vps_firewall_test.go
+++ b/resource_transip_vps_firewall_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTransipResourceVpsFirewall(t *testing.T) {
+	vpsName := os.Getenv("TF_VAR_vps_name")
+	testConfig := fmt.Sprintf(`
+
+	resource "transip_vps_firewall" "test" {
+	  name = "%s"
+
+	  inbound_rule {
+	    description = "HTTP"
+	    port        = "80"
+	    protocol    = "tcp"
+	  }
+
+	  inbound_rule {
+	    description = "HTTPS"
+	    port        = 443
+	    protocol    = "udp"
+	  }
+
+	  inbound_rule {
+	    description = "SSH"
+	    port        = 22
+	    protocol    = "tcp_udp"
+	  }
+
+	  inbound_rule {
+	    description = "RANGE"
+	    port        = "90-100"
+	    protocol    = "tcp"
+	  }
+	}
+	`, vpsName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:        testConfig,
+				ResourceName:  "transip_vps_firewall.test",
+				ImportState:   true,
+				ImportStateId: vpsName,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if s[0].ID != vpsName {
+						return fmt.Errorf("import failed")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/resource_transip_vps_firewall_test.go
+++ b/resource_transip_vps_firewall_test.go
@@ -83,18 +83,27 @@ func testAccTransipResourceVpsFirewall(name string) string {
 	    description = "HTTP"
 	    port        = "80"
 	    protocol    = "tcp"
+	    whitelist   = [
+	        "192.168.0.2/32",
+	        "::/128",
+	        "127.0.0.2/32",
+	        "127.0.0.1/32",
+	        "192.168.0.1/32",
+	    ]
 	  }
 
 	  inbound_rule {
 	    description = "HTTPS"
 	    port        = 443
 	    protocol    = "tcp"
+
 	  }
 
 	  inbound_rule {
 	    description = "SSH"
 	    port        = 22
 	    protocol    = "tcp"
+	    whitelist   = []
 	  }
 
 	  inbound_rule {

--- a/structures_vps.go
+++ b/structures_vps.go
@@ -7,9 +7,25 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/schema"
+
 	"github.com/transip/gotransip/v6/ipaddress"
 	"github.com/transip/gotransip/v6/vps"
 )
+
+// Transfrom the terraform rules to the API rules (FirewallRule)
+func vpsFirewallRulesExpand(inboundRules *schema.Set) ([]vps.FirewallRule, error) {
+	rules := make([]vps.FirewallRule, 0)
+	for _, rule := range inboundRules.List() {
+		r, err := vpsFirewallRuleExpand(rule)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, *r)
+	}
+
+	return rules, nil
+}
 
 // Transfrom the terraform rule to the API rule (FirewallRule)
 func vpsFirewallRuleExpand(i interface{}) (*vps.FirewallRule, error) {

--- a/structures_vps.go
+++ b/structures_vps.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/transip/gotransip/v6/ipaddress"
+	"github.com/transip/gotransip/v6/vps"
+)
+
+// Transfrom the terraform rule to the API rule (FirewallRule)
+func vpsFirewallRuleExpand(i interface{}) (*vps.FirewallRule, error) {
+	// Top level rule is <string> = <value>
+	rawRule := i.(map[string]interface{})
+	log.Printf("%+v\n", rawRule)
+
+	// Parse port (can be X or X-Y, if range, split it)
+	var startPort, endPort int
+	rawPorts := strings.Split(rawRule["port"].(string), "-")
+
+	if len(rawPorts) < 2 {
+		startPort, _ = strconv.Atoi(rawPorts[0])
+		endPort = startPort
+	} else {
+		startPort, _ = strconv.Atoi(rawPorts[0])
+		endPort, _ = strconv.Atoi(rawPorts[1])
+	}
+
+	// Parse whitelist IP addresses
+	rawAddresses := rawRule["whitelist"].([]interface{})
+	ipAdresses := make([]ipaddress.IPRange, len(rawAddresses))
+	for i, ip := range rawAddresses {
+		// Parse the IP
+		_, ipNetwork, err := net.ParseCIDR(ip.(string))
+
+		// Check if we had some trouble parsing
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q: %s", ip, err)
+		}
+
+		ipAdresses[i].IPNet = *ipNetwork
+	}
+
+	// Create the rule object
+	rule := &vps.FirewallRule{
+		Description: rawRule["description"].(string),
+		StartPort:   startPort,
+		EndPort:     endPort,
+		Protocol:    "tcp",
+		Whitelist:   ipAdresses,
+	}
+
+	return rule, nil
+}
+
+// Transform the API rule (FirewallRule) to terraform rule
+func vpsFirewallRuleFlatten(rule *vps.FirewallRule) map[string]interface{} {
+
+	// Parse the port
+	var port string
+	if rule.StartPort != rule.EndPort {
+		port = fmt.Sprintf("%d-%d", rule.StartPort, rule.EndPort)
+	} else {
+		port = strconv.Itoa(rule.StartPort)
+	}
+
+	// Parse the IP addresses
+	ipAdresses := make([]string, len(rule.Whitelist))
+	for i, ip := range rule.Whitelist {
+
+		ipAdresses[i] = ip.IPNet.String()
+	}
+
+	// Build
+	res := map[string]interface{}{
+		"description": rule.Description,
+		"protocol":    rule.Protocol,
+		"port":        port,
+		"whitelist":   ipAdresses,
+	}
+	return res
+}


### PR DESCRIPTION
My firewall rules where getting difficult to manage on Transip hence I tried to add support via Terraform.

I must say my Golang skills are rusty and I never worked on extending Terraform so please bare with me....

Now you can use these kind of structures:
```terraform
resource "transip_vps_firewall" "test" {
  name = "test"

  inbound_rule {
    description = "HTTP"
    port        = "80"
    protocol    = "tcp"
  }

  inbound_rule {
    description = "HTTPS"
    port        = 443
    protocol    = "udp"
  }

  inbound_rule {
    description = "SSH"
    port        = 22
    protocol    = "tcp_udp"
  }

  inbound_rule {
    description = "RANGE"
    port        = "90-100"
    protocol    = "tcp"
  }
}
```