### PR TITLE
DNS records more resilient and changed type to set

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -6,10 +6,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/transip/gotransip/v6"
 	"github.com/transip/gotransip/v6/authenticator"
 )
+
+var dnsDomainMutexKV = mutexkv.NewMutexKV()
 
 func envBoolFunc(k string) schema.SchemaDefaultFunc {
 	return func() (interface{}, error) {

--- a/resource_transip_dns_record.go
+++ b/resource_transip_dns_record.go
@@ -20,7 +20,7 @@ var errorStrings = []string{
 	"DNS Entries are currently being saved",
 }
 
-func retryableErrorf(err error, format string, a ...interface{}) *resource.RetryError {
+func retryableDNSRecordErrorf(err error, format string, a ...interface{}) *resource.RetryError {
 	// Check if this is a retryable error
 	isRetry := false
 	for _, errorString := range errorStrings {
@@ -145,7 +145,7 @@ func resourceDNSRecordRead(d *schema.ResourceData, m interface{}) error {
 		dnsEntries, err := repository.GetDNSEntries(domainName)
 
 		if err != nil {
-			return retryableErrorf(err, "failed to read DNS record entries for domain %s", domainName)
+			return retryableDNSRecordErrorf(err, "failed to read DNS record entries for domain %s", domainName)
 		}
 
 		if len(dnsEntries) == 0 {
@@ -193,7 +193,7 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 		log.Printf("[DEBUG] terraform-provider-transip update %s\n", entryName)
 		dnsEntries, err := repository.GetDNSEntries(domainName)
 		if err != nil {
-			return retryableErrorf(err, "failed to get existing DNS record entries for domain %s", domainName)
+			return retryableDNSRecordErrorf(err, "failed to get existing DNS record entries for domain %s", domainName)
 		}
 
 		// go through all dns entries in the zone (there is no way to read a single entry name)
@@ -207,7 +207,7 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 			log.Printf("[DEBUG] terraform-provider-transip %s removing %v\n", entryName, existingEntry)
 			err := repository.RemoveDNSEntry(domainName, existingEntry)
 			if err != nil {
-				return retryableErrorf(err, "failed to remove DNS record entry for domain %s (%v)", domainName, existingEntry)
+				return retryableDNSRecordErrorf(err, "failed to remove DNS record entry for domain %s (%v)", domainName, existingEntry)
 			}
 		}
 
@@ -224,7 +224,7 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 			err := repository.AddDNSEntry(domainName, dnsEntry)
 
 			if err != nil {
-				return retryableErrorf(err, "failed to add DNS record entry for domain %s (%v)", domainName, dnsEntry)
+				return retryableDNSRecordErrorf(err, "failed to add DNS record entry for domain %s (%v)", domainName, dnsEntry)
 			}
 		}
 

--- a/resource_transip_dns_record.go
+++ b/resource_transip_dns_record.go
@@ -148,6 +148,11 @@ func resourceDNSRecordRead(d *schema.ResourceData, m interface{}) error {
 			return retryableErrorf(err, "failed to read DNS record entries for domain %s", domainName)
 		}
 
+		if len(dnsEntries) == 0 {
+			d.SetId("")
+			return nil
+		}
+
 		var content []string
 		var expire int
 		for _, e := range dnsEntries {
@@ -156,10 +161,8 @@ func resourceDNSRecordRead(d *schema.ResourceData, m interface{}) error {
 				content = append(content, e.Content)
 			}
 		}
-		if len(content) == 0 {
-			d.SetId("")
-			return nil
-		}
+
+		log.Printf("[DEBUG] terraform-provider-transip reading record %s, %d, %s, %v\n", entryName, expire, entryType, content)
 
 		d.Set("name", entryName)
 		d.Set("expire", expire)
@@ -230,7 +233,7 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceDNSRecordDelete(d *schema.ResourceData, m interface{}) error {
-	d.Set("content", schema.NewSet(schema.HashString, make([]interface{}, 0)))
+	d.Set("content", make([]interface{}, 0))
 
 	return resourceDNSRecordUpdate(d, m)
 }

--- a/resource_transip_dns_record.go
+++ b/resource_transip_dns_record.go
@@ -8,9 +8,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/transip/gotransip/v6/domain"
 	"github.com/transip/gotransip/v6/repository"
 )
+
+// All errors that indicate a temporary failure
+var errorStrings = []string{
+	"Error setting Dns Entries",
+	"Internal error occurred, please contact our support",
+	"DNS Entries are currently being saved",
+}
+
+func retryableErrorf(err error, format string, a ...interface{}) *resource.RetryError {
+	// Check if this is a retryable error
+	isRetry := false
+	for _, errorString := range errorStrings {
+		if strings.Contains(err.Error(), errorString) {
+			isRetry = true
+			break
+		}
+	}
+
+	// Format the error
+	e := fmt.Errorf(format+": %s", append(a, err)...)
+
+	// Return the retryable error (retry or not)
+	if isRetry {
+		return resource.RetryableError(e)
+	} else {
+		return resource.NonRetryableError(e)
+	}
+}
 
 func resourceDNSRecord() *schema.Resource {
 	return &schema.Resource{
@@ -21,6 +50,7 @@ func resourceDNSRecord() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"domain": &schema.Schema{
 				Type:     schema.TypeString,
@@ -49,7 +79,7 @@ func resourceDNSRecord() *schema.Resource {
 				}, false),
 			},
 			"content": &schema.Schema{
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -67,11 +97,6 @@ func resourceDNSRecordCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := domain.Repository{Client: client}
 
-	// dom, err := domain.GetInfo(client, domainName)
-	// if err != nil {
-	//   return fmt.Errorf("failed to get domain %s for reading DNS record entries: %s", domainName, err)
-	// }
-
 	dnsEntries, err := repository.GetDNSEntries(domainName)
 	if err != nil {
 		return fmt.Errorf("failed to read DNS record entries for domain %s: %s", domainName, err)
@@ -83,6 +108,8 @@ func resourceDNSRecordCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	// Note: as soon as we use SetId, we assume the resource has been created.
+	// In this case that is not strictly true...
 	id := fmt.Sprintf("%s/%s/%s", domainName, entryType, entryName)
 	d.SetId(id)
 
@@ -91,9 +118,10 @@ func resourceDNSRecordCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceDNSRecordRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
+
 	// TODO: transip uniquely identifies the dnsentries using name, expire and type
 	// https://github.com/transip/gotransip/blob/9defadb50daea3d11821aed85498078b9aff4986/domain/repository.go#L148
-	// don't think it would hurt omiting the expire to keep compatible with older state files for now
+	// don't think it would hurt omitting the expire to keep compatible with older state files for now
 	if id != "" {
 		idparts := strings.Split(id, "/")
 		if len(idparts) == 3 {
@@ -112,38 +140,33 @@ func resourceDNSRecordRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := domain.Repository{Client: client}
 
-	dnsEntries, err := repository.GetDNSEntries(domainName)
-	if err != nil {
-		return fmt.Errorf("failed to read DNS record entries for domain %s: %s", domainName, err)
-	}
+	// We are now going to read from the domain (and retry)
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		dnsEntries, err := repository.GetDNSEntries(domainName)
 
-	var content []string
-	var expire int
-	for _, e := range dnsEntries {
-		if e.Name == entryName && e.Type == entryType {
-			expire = e.Expire
-			content = append(content, e.Content)
+		if err != nil {
+			return retryableErrorf(err, "failed to read DNS record entries for domain %s", domainName)
 		}
-	}
-	if len(content) == 0 {
-		d.SetId("")
+
+		var content []string
+		var expire int
+		for _, e := range dnsEntries {
+			if e.Name == entryName && e.Type == entryType {
+				expire = e.Expire
+				content = append(content, e.Content)
+			}
+		}
+		if len(content) == 0 {
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("name", entryName)
+		d.Set("expire", expire)
+		d.Set("type", entryType)
+		d.Set("content", content)
 		return nil
-	}
-
-	d.Set("name", entryName)
-	d.Set("expire", expire)
-	d.Set("type", entryType)
-	d.Set("content", content)
-	return nil
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	})
 }
 
 func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
@@ -152,22 +175,22 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 	entryName := d.Get("name").(string)
 	expire := d.Get("expire").(int)
 	entryType := d.Get("type").(string)
-	content := d.Get("content").([]interface{})
+	content := d.Get("content").(*schema.Set)
 
 	client := m.(repository.Client)
 	repository := domain.Repository{Client: client}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		log.Printf("[DEBUG] terraform-provider-transip update %s\n", entryName)
+		// We lock resources because Transip only allows one change per domain
+		// https://github.com/aequitas/terraform-provider-transip/issues/22
+		dnsDomainMutexKV.Lock(domainName)
+		defer dnsDomainMutexKV.Unlock(domainName)
 
+		// Read current entries to figure out what needs to be changed
+		log.Printf("[DEBUG] terraform-provider-transip update %s\n", entryName)
 		dnsEntries, err := repository.GetDNSEntries(domainName)
 		if err != nil {
-			// This error props up often when doing concurrent requests, so probably related to
-			// internal locking of the database? Similar as with the SOAP API.
-			if strings.Contains(err.Error(), "Internal error occurred, please contact our support") {
-				return resource.RetryableError(fmt.Errorf("failed to get existing DNS record entries for domain %s: %s", domainName, err))
-			}
-			return resource.NonRetryableError(fmt.Errorf("failed to get existing DNS record entries for domain %s: %s", domainName, err))
+			return retryableErrorf(err, "failed to get existing DNS record entries for domain %s", domainName)
 		}
 
 		// go through all dns entries in the zone (there is no way to read a single entry name)
@@ -176,34 +199,29 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 			if existingEntry.Name != entryName || existingEntry.Type != entryType {
 				continue
 			}
-			log.Printf("[DEBUG] terraform-provider-transip %s removing %v\n", entryName, existingEntry)
+
 			// remove all entries for the current entry/expiry/type combination
+			log.Printf("[DEBUG] terraform-provider-transip %s removing %v\n", entryName, existingEntry)
 			err := repository.RemoveDNSEntry(domainName, existingEntry)
 			if err != nil {
-				// This error props up often when doing concurrent requests, so probably related to
-				// internal locking of the database? Similar as with the SOAP API.
-				if strings.Contains(err.Error(), "Internal error occurred, please contact our support") {
-					return resource.RetryableError(fmt.Errorf("failed to remove DNS record entry for domain %s (%v): %s", domainName, existingEntry, err))
-				}
-				return resource.NonRetryableError(fmt.Errorf("failed to remove DNS record entry for domain %s (%v): %s", domainName, existingEntry, err))
+				return retryableErrorf(err, "failed to remove DNS record entry for domain %s (%v)", domainName, existingEntry)
 			}
 		}
 
 		// add all desired entries for the current entry/expiry/type combination
-		for _, c := range content {
+		for _, c := range content.List() {
 			dnsEntry := domain.DNSEntry{
 				Name:    entryName,
 				Expire:  expire,
 				Type:    entryType,
 				Content: c.(string),
 			}
+
 			log.Printf("[DEBUG] terraform-provider-transip: %s adding %v\n", entryName, dnsEntry)
 			err := repository.AddDNSEntry(domainName, dnsEntry)
+
 			if err != nil {
-				if strings.Contains(err.Error(), "Internal error occurred, please contact our support") {
-					return resource.RetryableError(fmt.Errorf("failed to add DNS record entry for domain %s (%v): %s", domainName, dnsEntry, err))
-				}
-				return resource.NonRetryableError(fmt.Errorf("failed to add DNS record entry for domain %s (%v): %s", domainName, dnsEntry, err))
+				return retryableErrorf(err, "failed to add DNS record entry for domain %s (%v)", domainName, dnsEntry)
 			}
 		}
 
@@ -212,7 +230,7 @@ func resourceDNSRecordUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceDNSRecordDelete(d *schema.ResourceData, m interface{}) error {
-	d.Set("content", []string{})
+	d.Set("content", schema.NewSet(schema.HashString, make([]interface{}, 0)))
 
 	return resourceDNSRecordUpdate(d, m)
 }

--- a/resource_transip_dns_record_test.go
+++ b/resource_transip_dns_record_test.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
-	"regexp"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccTransipResourceDomain(t *testing.T) {
@@ -31,7 +31,7 @@ func TestAccTransipResourceDomain(t *testing.T) {
 			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("transip_dns_record.test1", "content.0", "@"),
+					resource.TestCheckResourceAttr("transip_dns_record.test1", "content.#", "1"),
 				),
 			},
 		},
@@ -60,7 +60,7 @@ func TestAccTransipResourceDomainMultiple(t *testing.T) {
 			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("transip_dns_record.test2", "content.0", regexp.MustCompile("192.0.2.[0-3]")),
+					resource.TestCheckResourceAttr("transip_dns_record.test2", "content.#", "4"),
 				),
 			},
 		},
@@ -105,25 +105,20 @@ func TestAccTransipResourceDomainUpdate(t *testing.T) {
 			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("transip_dns_record.test7", "content.0", regexp.MustCompile("192.0.2.[01]")),
-					resource.TestMatchResourceAttr("transip_dns_record.test7", "content.1", regexp.MustCompile("192.0.2.[01]")),
+					resource.TestCheckResourceAttr("transip_dns_record.test7", "content.#", "2"),
 				),
 			},
 			{
 				Config: testConfig2,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("transip_dns_record.test7", "content.0", regexp.MustCompile("192.0.2.[23]")),
-					resource.TestMatchResourceAttr("transip_dns_record.test7", "content.1", regexp.MustCompile("192.0.2.[23]")),
+					resource.TestCheckResourceAttr("transip_dns_record.test7", "content.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-// TODO: concurrency seems broken on the Transip side, needs more testing to prove
 func TestAccTransipResourceDomainConcurrent(t *testing.T) {
-	t.Skip("concurrency is currently broken, skipping")
-
 	timestamp := time.Now().Unix()
 	testConfig := fmt.Sprintf(`
   terraform { required_version = ">= 0.12.0" }
@@ -154,18 +149,15 @@ func TestAccTransipResourceDomainConcurrent(t *testing.T) {
 			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("transip_dns_record.test3", "content.0", "@"),
-					resource.TestCheckResourceAttr("transip_dns_record.test4", "content.0", "@"),
+					resource.TestCheckResourceAttr("transip_dns_record.test3", "content.#", "1"),
+					resource.TestCheckResourceAttr("transip_dns_record.test4", "content.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-// TODO: concurrency seems broken on the Transip side, needs more testing to prove
 func TestAccTransipResourceDomainConcurrentMultiple(t *testing.T) {
-	t.Skip("concurrency is currently broken, skipping")
-
 	timestamp := time.Now().Unix()
 	testConfig := fmt.Sprintf(`
   terraform { required_version = ">= 0.12.0" }
@@ -196,8 +188,8 @@ func TestAccTransipResourceDomainConcurrentMultiple(t *testing.T) {
 			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("transip_dns_record.test5", "content.0", regexp.MustCompile("192.0.2.[01]")),
-					resource.TestMatchResourceAttr("transip_dns_record.test6", "content.0", regexp.MustCompile("192.0.2.[23]")),
+					resource.TestCheckResourceAttr("transip_dns_record.test5", "content.#", "2"),
+					resource.TestCheckResourceAttr("transip_dns_record.test6", "content.#", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
As discussed in #22, using a Mutex and using more retry errors, this provider is now much more resilient to the quirks thrown by Transip.

Also changed content type to `schema.TypeSet` to prevent Terraform from recreating records when Transip returns the records in a different order.