### PR TITLE
Hardened private network attachment

### DIFF
--- a/resource_transip_private_network_attachment.go
+++ b/resource_transip_private_network_attachment.go
@@ -41,7 +41,8 @@ func resourcePrivateNetworkAttachment() *schema.Resource {
 func resourcePrivateNetworkAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	errorStrings := []string{
 		"has an action running, no modification is allowed",
-		"is already locked to another action"}
+		"is already locked to another action",
+		"EOF"}
 
 	privateNetworkID := d.Get("private_network_id").(string)
 	vpsID := d.Get("vps_id").(string)


### PR DESCRIPTION
After some heavy testing on the private network attachment, I noticed TransIP's API seems to return more error strings than I initially anticipated for. I fixed this by creating a small list of strings that contain all possible retryable errors.

I've tested this for multiple deployments and it seems to be way more reliable now.