### PR TITLE
Improve reliability of VPS creation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ comma=,
 _targets = $(addprefix -target=,$(subst ${comma}, ,${targets}))
 
 apply: init
-	terraform apply -parallelism=1 ${_targets} examples/
+	terraform apply ${_targets} examples/
+
+destroy: init
+	terraform destroy ${_targets} examples/
 
 plan: init
 	terraform plan -detailed-exitcode ${_targets} examples/

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ resource "transip_dns_record" "www" {
 
 # VPS Server with setup script and DNS record
 resource "transip_vps" "test" {
-  name = "example"
+  description = "example"
   product_name = "vps-bladevps-x1"
   operating_system = "ubuntu-18.04"
 
@@ -140,7 +140,7 @@ resource "transip_dns_record" "testv6" {
 
 # Get an existing VPS as datasource
 data "transip_vps" "test" {
-  name = "example"
+  description = "example"
 }
 
 # Set hostname for VPS using data source

--- a/examples/vps.tf
+++ b/examples/vps.tf
@@ -7,12 +7,12 @@ variable "vps_product" {
 }
 
 variable "vps_os" {
-  default = "Debian 6"
+  default = "ubuntu-20.04"
 }
 
 # order a new VPS, or use `terraform import transip_vps.test test` to import existing one
 resource "transip_vps" "test" {
-  name = var.vps_name
+  description = var.vps_name
   product_name = var.vps_product
   operating_system = var.vps_os
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aequitas/terraform-provider-transip
 go 1.13
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/transip/gotransip/v6 v6.0.2
 )

--- a/resource_transip_vps_test.go
+++ b/resource_transip_vps_test.go
@@ -18,11 +18,10 @@ func TestAccTransipResourceVpsImport(t *testing.T) {
 
 	testConfig := fmt.Sprintf(`
 	resource "transip_vps" "test" {
-		name             = "%s"
     product_name     = "vps-bladevps-x1"
     operating_system = "Debian 6"
 	}
-	`, vpsName)
+	`)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -52,7 +51,7 @@ func TestAccTransipResourceVps(t *testing.T) {
 	timestamp := time.Now().Unix()
 	testConfig := fmt.Sprintf(`
 	resource "transip_vps" "test" {
-		name             = "test-%d"
+		description             = "test-%d"
     product_name     = "vps-bladevps-x1"
     operating_system = "ubuntu-20.04"
 	}


### PR DESCRIPTION
Fixes: https://github.com/aequitas/terraform-provider-transip/issues/19

- Don't assign resource `name` to VPS `description` in API. `name` is generated by Transip as a unique value so can't be used configured.
- Hijack `description` temporary to more reliably get the VPS that was just created as get `name` a usable unique ID.
- Work around issue where the API requires a OS name to create a VPS but returns the OS description in subsequent API calls.