### PR TITLE
Lock VPS from Terraform

### DIFF
--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -89,9 +89,11 @@ func resourceVps() *schema.Resource {
 				Type:        schema.TypeBool,
 			},
 			"is_customer_locked": {
-				Computed:    true,
+				Optional:    true,
 				Description: "If this VPS is locked by the customer.",
 				Type:        schema.TypeBool,
+				Default:     false,
+				ForceNew:    false,
 			},
 			"availability_zone": {
 				Optional:    true,
@@ -303,8 +305,7 @@ func resourceVpsUpdate(d *schema.ResourceData, m interface{}) error {
 	description := d.Get("description").(string)
 
 	vps := vps.Vps{
-		// Unique ID provided by TransIP
-		Name:             d.Id(),
+		Name:             d.Id(), // Unique ID provided by TransIP
 		Description:      description,
 		DiskSize:         d.Get("disk_size").(int64),
 		MemorySize:       d.Get("memory_size").(int64),

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -303,24 +303,22 @@ func resourceVpsRead(d *schema.ResourceData, m interface{}) error {
 func resourceVpsUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := vps.Repository{Client: client}
-	description := d.Get("description").(string)
-	diskSize := d.Get("disk_size").(int)
-	memorySize := d.Get("memory_size").(int)
 
 	vps := vps.Vps{
-		Name:        d.Id(), // Unique ID provided by TransIP
-		Description: description,
-		// TransIP API expects int64, while Terraform Schema expects TypeInt.
-		DiskSize:         int64(diskSize),
-		MemorySize:       int64(memorySize),
+		Name:             d.Id(), // Unique ID provided by TransIP
+		Description:      d.Get("description").(string),
 		CPUs:             d.Get("cpus").(int),
 		IsCustomerLocked: d.Get("is_customer_locked").(bool),
+
+		// TransIP API expects int64, while Terraform Schema expects TypeInt.
+		DiskSize:   int64(d.Get("disk_size").(int)),
+		MemorySize: int64(d.Get("memory_size").(int)),
 	}
 
 	err := repository.Update(vps)
 
 	if err != nil {
-		return fmt.Errorf("failed to update vps %s with id %q: %s", description, d.Id(), err)
+		return fmt.Errorf("failed to update vps %s with id %q: %s", d.Get("description").(string), d.Id(), err)
 	}
 	return resourceVpsRead(d, m)
 }

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -303,12 +303,15 @@ func resourceVpsUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(repository.Client)
 	repository := vps.Repository{Client: client}
 	description := d.Get("description").(string)
+	diskSize := d.Get("disk_size").(int)
+	memorySize := d.Get("memory_size").(int)
 
 	vps := vps.Vps{
-		Name:             d.Id(), // Unique ID provided by TransIP
-		Description:      description,
-		DiskSize:         d.Get("disk_size").(int64),
-		MemorySize:       d.Get("memory_size").(int64),
+		Name:        d.Id(), // Unique ID provided by TransIP
+		Description: description,
+		// TransIP API expects int64, while Terraform Schema expects TypeInt.
+		DiskSize:         int64(diskSize),
+		MemorySize:       int64(memorySize),
 		CPUs:             d.Get("cpus").(int),
 		IsCustomerLocked: d.Get("is_customer_locked").(bool),
 	}

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -236,7 +236,8 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 		if d.Id() == "" {
 			return resource.RetryableError(fmt.Errorf("Failed to set ID for VPS %s", d.Id()))
 		}
-		return resource.NonRetryableError(resourceVpsRead(d, m))
+		// Update first instead of read, as if user sets is_customer_locked to true it won't be set until a second apply is done.
+		return resource.NonRetryableError(resourceVpsUpdate(d, m))
 	})
 }
 


### PR DESCRIPTION
As of right now the provider has no support for setting the Customer Lock for a VPS (only for reading). In our workflow we like to set the Customer Lock directly after ordering, as we've had some issues with the front-end before where the wrong VPS got modified, upgraded or even deleted. 

When ordering a VPS, TransIP's API does not support setting a Customer Lock on the VPS directly. However, when updating the VPS after you've ordered it, you'll be able to set the Lock. Hence why I added the Update function and changed line 236 to Update instead of Read the VPS, so the lock will be set if configured; even when the VPS was not created yet.

If you've got any feedback or suggestions, please let me know.