### PR TITLE
Update development suite for Terraform 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .terraform/
 *.tfstate*
 *.tfvars
+.terraform.lock.*
 
 terraform-provider-*
 

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,11 @@ destroy: init
 plan: init
 	terraform plan -detailed-exitcode ${_targets} examples/
 
-init: .terraform/plugins/darwin_amd64/lock.json
-
-.terraform/plugins/darwin_amd64/lock.json: terraform.d/plugins/${os}_${arch}/terraform-provider-transip_${version} | terraform
+init: ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version} | terraform
 	terraform init examples/
 
-install: terraform.d/plugins/${os}_${arch}/terraform-provider-transip_${version}
-terraform.d/plugins/${os}_${arch}/terraform-provider-transip_${version}:  build/${os}_${arch}/terraform-provider-transip_${version}
+install: ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version}
+${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version}:  build/${os}_${arch}/terraform-provider-transip_${version}
 	mkdir -p ${@D}
 	cp $< $@
 
@@ -67,6 +65,7 @@ docs: | init
 clean:
 	rm -rf terraform-provider-transip* build/ docs/
 	rm -rf .terraform/ terraform.tfstate
+	rm -rf ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip
 
 mrproper: clean
 	go clean -modcache

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ plan: init
 	terraform plan -detailed-exitcode ${_targets} examples/
 
 init: ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version} | terraform
-	terraform init examples/
+	-rm .terraform.lock.hcl 
+	terraform init examples/ 
 
 install: ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version}
 ${HOME}/.terraform.d/plugins/registry.terraform.io/aequitas/transip/${version:v%=%}/${os}_${arch}/terraform-provider-transip_${version}:  build/${os}_${arch}/terraform-provider-transip_${version}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,1 +1,8 @@
 provider "transip" { }
+terraform {
+  required_providers {
+    transip = {
+      source  = "aequitas/transip"
+     }
+  }
+}


### PR DESCRIPTION
In newer versions Terraform expects local mirrors of the provider on another location: 
https://www.terraform.io/docs/cli/config/config-file.html#implied-local-mirror-directories

I've modified the `Makefile` to make use of these new file paths which allows you to initialise the project when running the newer Terraform version.