### PR TITLE
Bugfixes for TransIP Virtual Datacenter resources (OpenStack)

### DIFF
--- a/data_source_transip_openstack_user.go
+++ b/data_source_transip_openstack_user.go
@@ -25,7 +25,7 @@ func dataSourceOpenstackUser() *schema.Resource {
 			"email": {
 				Type:        schema.TypeString,
 				Description: "Email",
-				Required:    true,
+				Optional:    true,
 			},
 		},
 	}

--- a/resource_transip_openstack_project.go
+++ b/resource_transip_openstack_project.go
@@ -37,14 +37,14 @@ func resourceOpenstackProject() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Set to true when an ongoing process blocks the project from being modified",
 				Required:    false,
-				Optional:    true,
+				Computed:    true,
 				ForceNew:    false,
 			},
 			"blocked": {
 				Type:        schema.TypeBool,
 				Description: "Set to true when a project has been administratively blocked",
 				Required:    false,
-				Optional:    true,
+				Computed:    true,
 				ForceNew:    false,
 			},
 		},
@@ -112,8 +112,8 @@ func resourceOpenstackProjectUpdate(d *schema.ResourceData, m interface{}) error
 		ID:          d.Id(),
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		IsLocked:    d.Get("islocked").(bool),
-		IsBlocked:   d.Get("isblocked").(bool),
+		// IsLocked:    d.Get("islocked").(bool),
+		// IsBlocked:   d.Get("isblocked").(bool),
 	})
 
 	return resourceOpenstackProjectRead(d, m)

--- a/resource_transip_openstack_user.go
+++ b/resource_transip_openstack_user.go
@@ -82,12 +82,10 @@ func resourceOpenstackUserCreate(d *schema.ResourceData, m interface{}) error {
 		}
 		var found bool
 		// get ID of openstack project
-		for _, user := range users {
-			log.Printf("GETTING ALL THE USERS!!! %v", user)
-		}
+		log.Printf("[DEBUG] listing all users from openstack %v", users)
 		for _, user := range users {
 			if user.Username == d.Get("username") {
-				log.Printf("found id %v for user %v\n", user.Username, user.ID)
+				log.Printf("[DEBUG] found id %v for user %v\n", user.Username, user.ID)
 				d.SetId(user.ID)
 				found = true
 				break


### PR DESCRIPTION
Unfortunately after some further testing this morning I came across a few bugs in the `transip_openstack_*` resources:
* Sometimes when creating a new user in OpenStack it's not directly returned and thus no UserId is available yet. Fixed with a RetryableError
* Converted Locked/Blocked values to computed as they were returned empty if not set, resulting in a typeError
* Openstack User Data source had multiple required fields, which is not necessary 

@aequitas Hope you can still incorporate these changes in latest release. Sorry for the inconvenience