### PR TITLE
Force recreating DNS record when type changes

### DIFF
--- a/resource_transip_dns_record.go
+++ b/resource_transip_dns_record.go
@@ -80,6 +80,7 @@ func resourceDNSRecord() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The type of dns entry. Possbible types are 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV', 'SSHFP' and 'TLSA'.",
 				Required:    true,
+				ForceNew:    true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"A", "AAAA", "CAA", "CNAME", "MX", "NS", "TXT", "SRV", "SSHFP", "TLSA",
 				}, false),


### PR DESCRIPTION
When updating the type of a DNS record resource, the old record is not removed because only records that match the new type of the resource are removed. A new record with the new type is created though.

The resource keeps tracking the old record, because the type is part of the ID, and the ID does not change. While it is technically possible to update the ID, it rarely happens. When the type of a DNS record changes, it can also be considered a new record because the meaning of the record changes significantly.