### PR TITLE
fix: Empty ID's shouldn't trigger a RetryableError

### DIFF
--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -231,7 +231,7 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 			d.SetId(v.Name)
 		}
 		if d.Id() == "" {
-			return resource.RetryableError(fmt.Errorf("Failed to set ID for VPS %s", d.Id()))
+			return resource.NonRetryableError(fmt.Errorf("failed to set ID for VPS %s", d.Id()))
 		}
 		return resource.NonRetryableError(resourceVpsRead(d, m))
 	})


### PR DESCRIPTION
As found out in #58, this error doesn't have to be retry-able, as this may induce an unnecessarily long wait until a timeout occurs.
https://github.com/aequitas/terraform-provider-transip/blob/1a72a5c3bfaa4aab2f5c9b6b8bc16ee5897659a0/resource_transip_vps.go#L233-L234

Whenever `d.Id()` is empty after updating the resource through the API, there's probably something wrong enough not to retry it.

Signed-off-by: Joost Buskermolen <joost@buskervezel.nl>