### PR TITLE
Add domain_dnssec and domain_nameserver docs

### DIFF
--- a/docs/resources/domain_dnssec.md
+++ b/docs/resources/domain_dnssec.md
@@ -1,0 +1,21 @@
+# Domain DNSSec Resource
+
+Allows to set non default (ie. non TransIP provide) DNS Sec records.
+Use together with `domain_nameservers` to safely use another DNS Provider (ie
+Cloudflare, AWS Route53, ....)
+
+## Argument Reference
+
+* `domain` - (Required) The domain, including the tld
+* `dnssec` - (Required) List of dnssec entries associated with domain
+
+### DNSSec object
+
+* `key_tag` - (Required) A 5-digit key of the Zonesigner
+* `flags` - (Required) The signing key number, either 256 (Zone Signing Key) or 257 (Key Signing Key)
+* `algorithm` - (Required) The algorithm type that is used, see: https://www.transip.nl/vragen/461-domeinnaam-nameservers-gebruikt-beveiligen-dnssec/ for the possible options.
+* `public_key` - (Required) The public key
+
+## Attribute Reference
+
+* `id` - n/a

--- a/docs/resources/domian_nameservers.md
+++ b/docs/resources/domian_nameservers.md
@@ -1,0 +1,21 @@
+# Domain Nameservers Resource
+
+Allows to set non default (ie. non TransIP provide) nameservers.
+
+Use together with `domain_dnssec` to safely use another DNS Provider (ie
+Cloudflare, AWS Route53, ....)
+
+## Argument Reference
+
+* `domain` - (Required) The domain, including the tld
+* `nameserver` - (Required) List of nameservers associated with domain
+
+### Nameserver object
+
+* `hostname` - (Required) The hostname of this nameserver
+* `ipv4` - (Optional) ipv4 glue record for this nameserver
+* `ipv6` - (Optional) ipv6 glue record for this nameserver
+
+## Attribute Reference
+
+* `id` - n/a


### PR DESCRIPTION
Just provided MD files so documentation will appear on https://registry.terraform.io/providers/aequitas/transip/latest/docs

I was actually looking for these 2 resources and wanted to add a missing feature ticket, when I noticed by looking at the code it already existed....