### PR TITLE
Added 'ALIAS' option to the validation function and documentation.

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -8,7 +8,7 @@
 * `domain` - (Required) The name, including the tld of the domain.
 * `expire` - (Optional) The expiration period of the dns entry, in seconds. For example 86400 for a day of expiration.
 * `name` - (Required) The name of the dns entry, for example '@' or 'www'.
-* `type` - (Required) The type of dns entry. Possbible types are 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV', 'SSHFP' and 'TLSA'.
+* `type` - (Required) The type of dns entry. Possbible types are 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV', 'SSHFP', 'TLSA' and 'ALIAS'.
 
 ## Attribute Reference
 

--- a/resource_transip_dns_record.go
+++ b/resource_transip_dns_record.go
@@ -79,10 +79,10 @@ func resourceDNSRecord() *schema.Resource {
 			},
 			"type": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: "The type of dns entry. Possbible types are 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV', 'SSHFP' and 'TLSA'.",
+				Description: "The type of dns entry. Possbible types are 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'TXT', 'SRV', 'SSHFP', 'TLSA' and 'ALIAS'.",
 				Required:    true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"A", "AAAA", "CAA", "CNAME", "MX", "NS", "TXT", "SRV", "SSHFP", "TLSA",
+					"A", "AAAA", "CAA", "CNAME", "MX", "NS", "TXT", "SRV", "SSHFP", "TLSA", "ALIAS"
 				}, false),
 			},
 			"content": &schema.Schema{


### PR DESCRIPTION
Problem: ALIAS records are blocked from being created.

Solution: Add ALIAS value to validation function of the DNS Record Resource.

At the moment this Terraform provider is used for all our DNS records, now due to some technical limitations we need to start using ALIAS records for our root domains. TransIP support said that it's possible to create an ALIAS record regardless of the documentation. It seemed to be outdated. After verifying that it's possible, I created this PR to remove the ALIAS type limitation from the `dns_record` resource.

Please let me know if there is anything I can do to help to get the PR merged. 