### PR TITLE
fix: include timetzdata tag in dev builds (#55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ terraform-provider-transip_${version}_%_${arch}.tgz: build/%_${arch}/terraform-p
 	tar -zcf $@ -C ${<D} ${<F}
 
 build/%_${arch}/terraform-provider-transip_${version}: $(wildcard *.go) go.mod
-	mkdir -p ${@D}; GOOS=$* go build -o $@
+	mkdir -p ${@D}; GOOS=$* go build -tags=timetzdata -o $@
 
 test_acc: test
 test_acc: TF_ACC=1


### PR DESCRIPTION
Adds `-tags=timetzdata` to the Makefile dev build command so local builds also include timezone data, fixing the 'unknown time zone' error in environments without system tzdata.

Previously only goreleaser release builds had this flag (see .goreleaser.yml). This brings the Makefile in sync with release builds.

Fixes #55