### PR TITLE
feat: add validation for install_flavour and update docs (#29)

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -6,7 +6,8 @@
 
 * `availability_zone` - (Optional) The name of the availability zone the VPS is in.
 * `description` - (Optional) The name that can be set by customer.
-* `install_text` - (Optional) Base64 encoded preseed / kickstart / cloudinit instructions, when installing unattended.
+* `install_text` - (Optional) Base64 encoded preseed / kickstart / cloudinit instructions, when installing unattended. Provide plain text, not base64 encoded — the provider encodes it automatically.
+* `install_flavour` - (Optional) The flavour of OS installation. Must be one of: `installer`, `preinstallable` or `cloudinit`. Defaults to `installer` when not specified. Use `cloudinit` when using cloud-init in `install_text`.
 * `operating_system` - (Required) The VPS OperatingSystem.
 * `product_name` - (Required) The product name.
 

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/transip/gotransip/v6"
 	"github.com/transip/gotransip/v6/product"
 	"github.com/transip/gotransip/v6/repository"
@@ -114,13 +115,16 @@ func resourceVps() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
-			"install_flavour": {
-				Type:        schema.TypeString,
-				Default:     "",
-				Description: "The flavour of OS installation: 'installer', 'preinstallable' or 'cloudinit'.",
-				Optional:    true,
-				ForceNew:    true,
-			},
+		"install_flavour": {
+			Type:        schema.TypeString,
+			Default:     "",
+			Description: "The flavour of OS installation: 'installer', 'preinstallable' or 'cloudinit'.",
+			Optional:    true,
+			ForceNew:    true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"", "installer", "preinstallable", "cloudinit",
+			}, false),
+		},
 			"ipv4_addresses": {
 				Type:        schema.TypeList,
 				Description: "All IPV4 addresses associated with this VPS.",


### PR DESCRIPTION
Adds `ValidateFunc` to the `install_flavour` field on the VPS resource to restrict values to `installer`, `preinstallable`, `cloudinit`, or empty (default).\n\nAlso updates the VPS documentation to properly document `install_flavour` and clarify that `install_text` must be plain text (not base64).\n\nFixes #29