### PR TITLE
fix: detect double-base64 encoding of install_text and update docs (#43)

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -6,7 +6,7 @@
 
 * `availability_zone` - (Optional) The name of the availability zone the VPS is in.
 * `description` - (Optional) The name that can be set by customer.
-* `install_text` - (Optional) Base64 encoded preseed / kickstart / cloudinit instructions, when installing unattended.
+* `install_text` - (Optional) Plain text preseed / kickstart / cloud-init instructions for unattended installation. The provider automatically base64 encodes this value. Do NOT provide pre-base64-encoded text, as this will cause double-encoding and corruption.
 * `operating_system` - (Required) The VPS OperatingSystem.
 * `product_name` - (Required) The product name.
 

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -4,9 +4,12 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
+	"log"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/transip/gotransip/v6"
 	"github.com/transip/gotransip/v6/product"
 	"github.com/transip/gotransip/v6/repository"
@@ -168,6 +171,11 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 	}
 	if !validProduct {
 		return fmt.Errorf("Product %s is invalid. Valid product names are: %v", productName, availableProducts)
+	}
+
+	_, err = base64.StdEncoding.DecodeString(installText)
+	if err == nil && len(installText) > 0 {
+		log.Printf("[WARN] install_text appears to be base64-encoded; double-encoding will occur. Provide plain text instead.")
 	}
 
 	base64InstallText := base64.StdEncoding.EncodeToString([]byte(installText))


### PR DESCRIPTION
Adds a warning when `install_text` appears to be already base64-encoded, which would cause double-encoding by the provider and corrupt the installation instructions.\n\nAlso updates the VPS documentation to clarify that `install_text` must be plain text, not base64.\n\nFixes #43