### PR TITLE
feat: add ssh_keys parameter for VPS installation (#30)

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -7,6 +7,7 @@
 * `availability_zone` - (Optional) The name of the availability zone the VPS is in.
 * `description` - (Optional) The name that can be set by customer.
 * `install_text` - (Optional) Base64 encoded preseed / kickstart / cloudinit instructions, when installing unattended.
+* `ssh_keys` - (Optional) List of public SSH keys to configure for the initial user during installation (cloud-init flavour only).
 * `operating_system` - (Required) The VPS OperatingSystem.
 * `product_name` - (Required) The product name.
 

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -121,6 +121,15 @@ func resourceVps() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"ssh_keys": {
+				Type:        schema.TypeList,
+				Description: "Array of public SSH keys to use for account creating during installation (currently only supported with the cloudinit flavour).",
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"ipv4_addresses": {
 				Type:        schema.TypeList,
 				Description: "All IPV4 addresses associated with this VPS.",
@@ -177,6 +186,11 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 	// Must be no more than 32 characters, hence MD5 hash.
 	tempDescription := fmt.Sprintf("%x", md5.Sum([]byte(uuid.New().String())))
 
+	sshKeys := []string{}
+	for _, key := range d.Get("ssh_keys").([]interface{}) {
+		sshKeys = append(sshKeys, key.(string))
+	}
+
 	vpsOrder := vps.Order{
 		ProductName:       productName,
 		OperatingSystem:   operatingSystem,
@@ -186,6 +200,7 @@ func resourceVpsCreate(d *schema.ResourceData, m interface{}) error {
 		Addons:            addons,
 		Base64InstallText: base64InstallText,
 		InstallFlavour:    installFlavour,
+		SSHKeys:           sshKeys,
 	}
 
 	err = repository.Order(vpsOrder)


### PR DESCRIPTION
Adds an optional `ssh_keys` list parameter to the VPS resource. Public SSH keys are passed to the TransIP API during VPS creation and configured for the initial user (supports cloud-init install flavour).\n\nThe gotransip v6 library already supports this field in the `Order` struct.\n\nFixes #30