### PR TITLE
fix: add thread-safe token cache to prevent concurrent token label collisions (#71)

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -128,6 +128,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		panic(err.Error())
 	}
 
+	cache = newThreadSafeTokenCache(cache)
+
 	var client_configuration gotransip.ClientConfiguration
 
 	if private_key_body != "" {

--- a/threadsafe_token_cache.go
+++ b/threadsafe_token_cache.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/transip/gotransip/v6/authenticator"
+)
+
+type threadSafeTokenCache struct {
+	mu    sync.Mutex
+	cache authenticator.TokenCache
+}
+
+func newThreadSafeTokenCache(cache authenticator.TokenCache) *threadSafeTokenCache {
+	return &threadSafeTokenCache{cache: cache}
+}
+
+func (t *threadSafeTokenCache) Get() (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cache.Get()
+}
+
+func (t *threadSafeTokenCache) Store(token string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cache.Store(token)
+}


### PR DESCRIPTION
Wraps the gotransip `TokenCache` with a mutex to prevent concurrent token creation with the same timestamp-based label. When Terraform runs with parallelism >1, multiple goroutines may simultaneously check the cache, find no valid token, and both attempt to create a new token with the identical label (e.g. `gotransip-client-1681375048`), causing "label already used" errors.\n\nThe `threadSafeTokenCache` wraps the existing `FileTokenCache` with a `sync.Mutex` to serialize `Get` and `Store` operations.\n\nFixes #71