### PR TITLE
feat: add domain contacts resource (#79)

### DIFF
--- a/docs/resources/domain_contacts.md
+++ b/docs/resources/domain_contacts.md
@@ -1,0 +1,51 @@
+# Domain Contacts Resource
+
+Manages whois contacts for a domain.
+
+## Example Usage
+
+```hcl
+resource "transip_domain_contacts" "example" {
+  domain = "example.com"
+
+  contact {
+    type         = "registrant"
+    first_name   = "John"
+    last_name    = "Doe"
+    company_name = "Example Corp"
+    street       = "Voorbeeldstraat"
+    number       = "1"
+    postal_code  = "1000 AA"
+    city         = "Amsterdam"
+    phone_number = "+31.201234567"
+    email        = "john@example.com"
+    country      = "nl"
+  }
+}
+```
+
+## Argument Reference
+
+* `domain` - (Required) The domain name, including the tld.
+* `contact` - (Required) List of whois contacts. At least one contact is required.
+
+The `contact` block supports:
+
+* `type` - (Required) The type of contact: `registrant`, `administrative` or `technical`.
+* `first_name` - (Required) The first name.
+* `last_name` - (Required) The last name.
+* `company_name` - (Optional) The company name.
+* `company_kvk` - (Optional) The KVK number.
+* `company_type` - (Optional) The company type.
+* `street` - (Required) The street name.
+* `number` - (Required) The street number.
+* `postal_code` - (Required) The postal code.
+* `city` - (Required) The city.
+* `phone_number` - (Required) The phone number.
+* `fax_number` - (Optional) The fax number.
+* `email` - (Required) The email address.
+* `country` - (Required) The ISO 3166-1 alpha-2 country code (lowercase).
+
+## Attribute Reference
+
+* `id` - The domain name.

--- a/provider.go
+++ b/provider.go
@@ -66,6 +66,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"transip_dns_record":                 resourceDNSRecord(),
 			"transip_domain":                     resourceDomain(),
+			"transip_domain_contacts":             resourceDomainContacts(),
 			"transip_domain_nameservers":         resourceDomainNameservers(),
 			"transip_domain_dnssec":              resourceDomainDNSSec(),
 			"transip_vps":                        resourceVps(),

--- a/resource_transip_domain_contacts.go
+++ b/resource_transip_domain_contacts.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/transip/gotransip/v6/domain"
+	"github.com/transip/gotransip/v6/repository"
+)
+
+var validContactTypes = []string{"registrant", "administrative", "technical"}
+var validCompanyTypes = []string{"BV", "BVI/O", "COOP", "CV", "EENMANSZAAK", "KERK", "NV", "OWM", "REDR", "STICHTING", "VERENIGING", "VOF", "BEG", "BRO", "EESV", "ANDERS"}
+
+func resourceDomainContacts() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDomainContactsUpdate,
+		Read:   resourceDomainContactsRead,
+		Update: resourceDomainContactsUpdate,
+		Delete: resourceDomainContactsDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceDomainContactsImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:        schema.TypeString,
+				Description: "The domain name, including the tld.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"contact": {
+				Type:        schema.TypeList,
+				Description: "List of whois contacts for this domain.",
+				Required:    true,
+				MinItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Description:  "The type of contact: 'registrant', 'administrative' or 'technical'.",
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(validContactTypes, false),
+						},
+						"first_name": {
+							Type:        schema.TypeString,
+							Description: "The first name of this contact.",
+							Required:    true,
+						},
+						"last_name": {
+							Type:        schema.TypeString,
+							Description: "The last name of this contact.",
+							Required:    true,
+						},
+						"company_name": {
+							Type:        schema.TypeString,
+							Description: "The company name of this contact.",
+							Optional:    true,
+						},
+						"company_kvk": {
+							Type:        schema.TypeString,
+							Description: "The kvk number of this contact.",
+							Optional:    true,
+						},
+						"company_type": {
+							Type:         schema.TypeString,
+							Description:  "The company type. Possible values: 'BV', 'BVI/O', 'COOP', 'CV', 'EENMANSZAAK', 'KERK', 'NV', 'OWM', 'REDR', 'STICHTING', 'VERENIGING', 'VOF', 'BEG', 'BRO', 'EESV', 'ANDERS'.",
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(validCompanyTypes, false),
+						},
+						"street": {
+							Type:        schema.TypeString,
+							Description: "The street of the address of this contact.",
+							Required:    true,
+						},
+						"number": {
+							Type:        schema.TypeString,
+							Description: "The street number of the address of this contact.",
+							Required:    true,
+						},
+						"postal_code": {
+							Type:        schema.TypeString,
+							Description: "The postal code of the address of this contact.",
+							Required:    true,
+						},
+						"city": {
+							Type:        schema.TypeString,
+							Description: "The city of the address of this contact.",
+							Required:    true,
+						},
+						"phone_number": {
+							Type:        schema.TypeString,
+							Description: "The phone number of this contact.",
+							Required:    true,
+						},
+						"fax_number": {
+							Type:        schema.TypeString,
+							Description: "The fax number of this contact.",
+							Optional:    true,
+						},
+						"email": {
+							Type:        schema.TypeString,
+							Description: "The email address of this contact.",
+							Required:    true,
+						},
+						"country": {
+							Type:        schema.TypeString,
+							Description: "The country code (ISO 3166-1 alpha-2, lowercase) of this contact.",
+							Required:    true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								if len(val.(string)) != 2 {
+									errs = append(errs, fmt.Errorf("%q must be a 2-letter ISO country code", key))
+								}
+								return
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDomainContactsImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	d.Set("domain", d.Id())
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceDomainContactsRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(repository.Client)
+	repo := domain.Repository{Client: client}
+
+	domainName := d.Get("domain").(string)
+	contacts, err := repo.GetContacts(domainName)
+	if err != nil {
+		return fmt.Errorf("failed to get contacts of domain %q: %s", domainName, err)
+	}
+
+	err = d.Set("contact", whoisContactsToMaps(contacts))
+	if err != nil {
+		return fmt.Errorf("failed to set contacts for domain %q: %s", domainName, err)
+	}
+
+	d.SetId(domainName)
+	return nil
+}
+
+func resourceDomainContactsUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(repository.Client)
+	repo := domain.Repository{Client: client}
+
+	domainName := d.Get("domain").(string)
+	contacts := interfacesToWhoisContacts(d.Get("contact").([]interface{}))
+	err := repo.UpdateContacts(domainName, contacts)
+	if err != nil {
+		return fmt.Errorf("failed to update contacts of domain %q: %s", domainName, err)
+	}
+
+	d.SetId(domainName)
+	return nil
+}
+
+func resourceDomainContactsDelete(d *schema.ResourceData, m interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func whoisContactsToMaps(contacts []domain.WhoisContact) []map[string]interface{} {
+	maps := make([]map[string]interface{}, len(contacts))
+	for i, c := range contacts {
+		m := make(map[string]interface{})
+		m["type"] = c.Type
+		m["first_name"] = c.FirstName
+		m["last_name"] = c.LastName
+		m["company_name"] = c.CompanyName
+		m["company_kvk"] = c.CompanyKvk
+		m["company_type"] = c.CompanyType
+		m["street"] = c.Street
+		m["number"] = c.Number
+		m["postal_code"] = c.PostalCode
+		m["city"] = c.City
+		m["phone_number"] = c.PhoneNumber
+		m["fax_number"] = c.FaxNumber
+		m["email"] = c.Email
+		m["country"] = c.Country
+		maps[i] = m
+	}
+	return maps
+}
+
+func interfacesToWhoisContacts(interfaces []interface{}) []domain.WhoisContact {
+	contacts := make([]domain.WhoisContact, len(interfaces))
+	for i, v := range interfaces {
+		m := v.(map[string]interface{})
+		contacts[i] = domain.WhoisContact{
+			Type:        m["type"].(string),
+			FirstName:   m["first_name"].(string),
+			LastName:    m["last_name"].(string),
+			CompanyName: m["company_name"].(string),
+			CompanyKvk:  m["company_kvk"].(string),
+			CompanyType: m["company_type"].(string),
+			Street:      m["street"].(string),
+			Number:      m["number"].(string),
+			PostalCode:  m["postal_code"].(string),
+			City:        m["city"].(string),
+			PhoneNumber: m["phone_number"].(string),
+			FaxNumber:   m["fax_number"].(string),
+			Email:       m["email"].(string),
+			Country:     m["country"].(string),
+		}
+	}
+	return contacts
+}


### PR DESCRIPTION
Adds a new `transip_domain_contacts` resource for managing whois contacts on domains via the TransIP API.\n\n- Supports all `WhoisContact` fields from the TransIP API (type, first/last name, company info, address, phone, email)\n- Follows the pattern of `transip_domain_nameservers` (Create=Update pattern via PUT)\n- Includes validation for contact type, company type, and country code\n- Includes import support\n\nFixes #79