### PR TITLE
feat: make tags manageable on VPS resource (#12)

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -6,6 +6,7 @@
 
 * `availability_zone` - (Optional) The name of the availability zone the VPS is in.
 * `description` - (Optional) The name that can be set by customer.
+* `tags` - (Optional) The custom tags added to this VPS.
 * `install_text` - (Optional) Base64 encoded preseed / kickstart / cloudinit instructions, when installing unattended.
 * `operating_system` - (Required) The VPS OperatingSystem.
 * `product_name` - (Required) The product name.

--- a/resource_transip_vps.go
+++ b/resource_transip_vps.go
@@ -17,7 +17,7 @@ func resourceVps() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceVpsCreate,
 		Read:   resourceVpsRead,
-		// Update: resourceVpsUpdate,
+		Update: resourceVpsUpdate,
 		Delete: resourceVpsDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -99,14 +99,15 @@ func resourceVps() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
-			"tags": {
-				Type:        schema.TypeList,
-				Description: "The custom tags added to this VPS.",
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:        schema.TypeList,
+			Description: "The custom tags added to this VPS.",
+			Optional:    true,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
+		},
 			"install_text": {
 				Type:        schema.TypeString,
 				Default:     "",
@@ -285,6 +286,31 @@ func resourceVpsRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceVpsUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(repository.Client)
+	repository := vps.Repository{Client: client}
+
+	v, err := repository.GetByName(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to lookup vps %q: %s", d.Id(), err)
+	}
+
+	v.Description = d.Get("description").(string)
+
+	tags := []string{}
+	for _, tag := range d.Get("tags").([]interface{}) {
+		tags = append(tags, tag.(string))
+	}
+	v.Tags = tags
+
+	err = repository.Update(v)
+	if err != nil {
+		return fmt.Errorf("failed to update VPS %q: %s", d.Id(), err)
+	}
+
+	return resourceVpsRead(d, m)
 }
 
 func resourceVpsDelete(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
Changes the VPS resource `tags` field from read-only (`Computed`) to user-settable (`Optional` + `Computed`).\n\nAlso enables the VPS `Update` function to support in-place updates of `description` and `tags` without destroying and recreating the VPS.\n\nFixes #12